### PR TITLE
Improve config file searching and error handling

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,5 +1,8 @@
-import { expect, test, describe } from "bun:test";
-import { extractBashCommands } from "../src/config.ts";
+import { expect, test, describe, beforeEach, afterEach } from "bun:test";
+import { extractBashCommands, loadConclaudeConfig } from "../src/config.ts";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
 
 describe("extractBashCommands", () => {
 	test("extracts single command", () => {
@@ -68,5 +71,173 @@ cd /tmp && echo "test"`;
    # Comment 3`;
 		const commands = extractBashCommands(script);
 		expect(commands).toEqual([]);
+	});
+});
+
+describe("loadConclaudeConfig", () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(() => {
+		// Create a temporary directory for testing
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "conclaude-test-"));
+		originalCwd = process.cwd();
+	});
+
+	afterEach(() => {
+		// Clean up temporary directory
+		fs.rmSync(tempDir, { recursive: true, force: true });
+		process.chdir(originalCwd);
+	});
+
+	const validConfigContent = `
+stop:
+  run: "echo test"
+rules:
+  preventRootAdditions: true
+  uneditableFiles: []
+`;
+
+	test("finds config in current directory", async () => {
+		const configPath = path.join(tempDir, ".conclaude.yaml");
+		fs.writeFileSync(configPath, validConfigContent);
+
+		const config = await loadConclaudeConfig(tempDir);
+		expect(config.stop.run).toBe("echo test");
+		expect(config.rules.preventRootAdditions).toBe(true);
+	});
+
+	test("finds .yml config file", async () => {
+		const configPath = path.join(tempDir, ".conclaude.yml");
+		fs.writeFileSync(configPath, validConfigContent);
+
+		const config = await loadConclaudeConfig(tempDir);
+		expect(config.stop.run).toBe("echo test");
+	});
+
+	test("searches parent directories", async () => {
+		// Create nested directory structure
+		const subDir = path.join(tempDir, "subdir");
+		fs.mkdirSync(subDir);
+		
+		// Place config in parent directory
+		const configPath = path.join(tempDir, ".conclaude.yaml");
+		fs.writeFileSync(configPath, validConfigContent);
+
+		const config = await loadConclaudeConfig(subDir);
+		expect(config.stop.run).toBe("echo test");
+	});
+
+	test("searches up to 2 parent directories", async () => {
+		// Create nested directory structure: tempDir/level1/level2/level3
+		const level1Dir = path.join(tempDir, "level1");
+		const level2Dir = path.join(level1Dir, "level2");
+		const level3Dir = path.join(level2Dir, "level3");
+		fs.mkdirSync(level1Dir);
+		fs.mkdirSync(level2Dir);
+		fs.mkdirSync(level3Dir);
+		
+		// Place config in level1 directory (2 levels up from level3)
+		const configPath = path.join(level1Dir, ".conclaude.yaml");
+		fs.writeFileSync(configPath, validConfigContent);
+
+		const config = await loadConclaudeConfig(level3Dir);
+		expect(config.stop.run).toBe("echo test");
+	});
+
+	test("does not search beyond 2 parent directories", async () => {
+		// Create nested directory structure: tempDir/level1/level2/level3/level4
+		const level1Dir = path.join(tempDir, "level1");
+		const level2Dir = path.join(level1Dir, "level2");
+		const level3Dir = path.join(level2Dir, "level3");
+		const level4Dir = path.join(level3Dir, "level4");
+		fs.mkdirSync(level1Dir);
+		fs.mkdirSync(level2Dir);
+		fs.mkdirSync(level3Dir);
+		fs.mkdirSync(level4Dir);
+		
+		// Place config in tempDir (3 levels up from level4) - should NOT be found
+		const configPath = path.join(tempDir, ".conclaude.yaml");
+		fs.writeFileSync(configPath, validConfigContent);
+
+		await expect(loadConclaudeConfig(level4Dir)).rejects.toThrow("No .conclaude.yaml or .conclaude.yml configuration file found");
+	});
+
+	test("stops at git root", async () => {
+		// Create git repository in tempDir
+		const gitDir = path.join(tempDir, ".git");
+		fs.mkdirSync(gitDir);
+		
+		// Create nested directory structure beyond git root
+		const subDir = path.join(tempDir, "subdir");
+		const subSubDir = path.join(subDir, "subsubdir");
+		fs.mkdirSync(subDir);
+		fs.mkdirSync(subSubDir);
+		
+		// Place config at git root
+		const configPath = path.join(tempDir, ".conclaude.yaml");
+		fs.writeFileSync(configPath, validConfigContent);
+
+		const config = await loadConclaudeConfig(subSubDir);
+		expect(config.stop.run).toBe("echo test");
+	});
+
+	test("provides detailed error message when config not found", async () => {
+		await expect(loadConclaudeConfig(tempDir)).rejects.toThrow(/No \.conclaude\.yaml or \.conclaude\.yml configuration file found/);
+		await expect(loadConclaudeConfig(tempDir)).rejects.toThrow(/Searched locations:/);
+	});
+
+	test("handles invalid YAML content", async () => {
+		const configPath = path.join(tempDir, ".conclaude.yaml");
+		fs.writeFileSync(configPath, "invalid: yaml: content: [");
+
+		await expect(loadConclaudeConfig(tempDir)).rejects.toThrow(/failed to parse YAML content/);
+	});
+
+	test("prefers .yaml over .yml when both exist", async () => {
+		const yamlConfig = `
+stop:
+  run: "echo yaml"
+rules:
+  preventRootAdditions: true
+  uneditableFiles: []
+`;
+		const ymlConfig = `
+stop:
+  run: "echo yml"
+rules:
+  preventRootAdditions: true
+  uneditableFiles: []
+`;
+		
+		fs.writeFileSync(path.join(tempDir, ".conclaude.yaml"), yamlConfig);
+		fs.writeFileSync(path.join(tempDir, ".conclaude.yml"), ymlConfig);
+
+		const config = await loadConclaudeConfig(tempDir);
+		expect(config.stop.run).toBe("echo yaml");
+	});
+
+	test("error message includes git root information", async () => {
+		// Create git repository in tempDir
+		const gitDir = path.join(tempDir, ".git");
+		fs.mkdirSync(gitDir);
+		
+		const subDir = path.join(tempDir, "subdir");
+		fs.mkdirSync(subDir);
+
+		try {
+			await loadConclaudeConfig(subDir);
+		} catch (error) {
+			expect((error as Error).message).toContain("Search was limited to git repository root:");
+			expect((error as Error).message).toContain(tempDir);
+		}
+	});
+
+	test("error message when no git repository found", async () => {
+		try {
+			await loadConclaudeConfig(tempDir);
+		} catch (error) {
+			expect((error as Error).message).toContain("No git repository found - searched up to filesystem root or maximum 2 parent directories");
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- Enhanced config file search to look up parent directories (up to git root, max 2 parents)
- Improved error messages showing exactly where configuration files were searched
- Added comprehensive test coverage for new search functionality
- Maintains backward compatibility with existing API

## Changes

### Configuration Search Improvements
- Searches `.conclaude.yaml` and `.conclaude.yml` in current directory first
- Searches up to 2 parent directories or until git root is reached
- Provides detailed error messages listing all searched locations
- Includes git root information in error messages for better debugging

### Test Coverage
- Added 11 new test cases covering various search scenarios
- Tests upward directory traversal behavior
- Tests git root boundary detection  
- Tests error message formatting
- Tests YAML parsing error handling

## Fixes

Closes #8

## Test Plan

- [x] All existing tests pass
- [x] New test cases verify correct search behavior
- [x] Type checking passes
- [x] Configuration files are found in parent directories
- [x] Search stops at git root as expected
- [x] Error messages are informative and helpful

🤖 Generated with [Claude Code](https://claude.ai/code)